### PR TITLE
Handle sampling cases where num_samples > num_nodes

### DIFF
--- a/main.py
+++ b/main.py
@@ -177,4 +177,4 @@ def evaluate(model,
     return accuracy
 
 
-train(Arguments().parse_args())
+train(Arguments(explicit_bool=True).parse_args())

--- a/modules/simple.py
+++ b/modules/simple.py
@@ -13,7 +13,7 @@ class KSubsetDistribution(torch.distributions.ExponentialFamily):
     def __init__(self, probs: torch.Tensor, K: int, log_space=True):
         # See https://arxiv.org/pdf/2210.01941.pdf, in particular Algorithm 1, 2 and 5 and 6
         self.probs = probs.squeeze()
-        assert K < self.probs.shape[-1]
+        assert K <= self.probs.shape[-1]
         if len(self.probs.shape) == 1:
             self.probs = self.probs.unsqueeze(0)
         self._bernoulli = Bernoulli(probs=self.probs)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -19,6 +19,7 @@ def sample_neighborhoods_from_probs(probabilities: torch.Tensor,
         num_samples: the number of samples to keep. If None, all edges are kept.
     """
     if num_samples > 0:
+        num_samples = min(probabilities.shape[0], num_samples)
         node_k_subset = KSubsetDistribution(probabilities, num_samples)
         node_samples = node_k_subset.sample()
         neighbor_nodes = neighbor_nodes[node_samples.long() == 1]


### PR DESCRIPTION
When the desired number of samples is higher than n = number of nodes in the batch, defaults to getting n samples.