### PR TITLE
Fix Errors Running Amazon and CoAuthor Datasets

### DIFF
--- a/modules/data.py
+++ b/modules/data.py
@@ -127,7 +127,7 @@ def get_wikics(root: str) -> Tuple[Data, int, int]:
 
 
 def get_coauthor(root: str, name: str) -> Tuple[Data, int, int]:
-    dataset = Coauthor(f'{root}/Coauthor', name, transform=T.ToSparseTensor())
+    dataset = Coauthor(f'{root}/Coauthor', name, transform=T.ToSparseTensor(remove_edge_index = False))
     data = dataset[0]
     torch.manual_seed(12345)
     data.train_mask, data.val_mask, data.test_mask = gen_masks(
@@ -136,7 +136,7 @@ def get_coauthor(root: str, name: str) -> Tuple[Data, int, int]:
 
 
 def get_amazon(root: str, name: str) -> Tuple[Data, int, int]:
-    dataset = Amazon(f'{root}/Amazon', name, transform=T.ToSparseTensor())
+    dataset = Amazon(f'{root}/Amazon', name, transform=T.ToSparseTensor(remove_edge_index = False))
     data = dataset[0]
     torch.manual_seed(12345)
     data.train_mask, data.val_mask, data.test_mask = gen_masks(

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -172,7 +172,7 @@ def gen_masks(y: Tensor, train_per_class: int = 20, val_per_class: int = 30,
 
     test_mask = ~(train_mask | val_mask)
 
-    return train_mask, val_mask, test_mask
+    return train_mask[:, 0], val_mask[:, 0], test_mask[:, 0]
 
 
 # Function to return memory usage in MB


### PR DESCRIPTION
I encountered issues while running the code with the Amazon and CoAuthor datasets. The first issue was in `modules/data.py`, where both the `get_coauthor` and `get_amazon` functions used the `T.ToSparseTensor` transform, which by default removes the edge index. The second issue was in the `gen_masks` function within `modules/utils.py`, where it was returning 2-dimensional train, validation, and test masks, causing issues in training and evaulation.

Changes made:
- Added `remove_edge_index=False` to `T.ToSparseTensor` for both the Amazon and CoAuthor datasets to preserve the edge index.
- Modified the `gen_masks` function to return 1D masks instead of 2D, ensuring compatibility with the subsequent operations in the training loop.

These changes resolve the issues and allow the Amazon and CoAuthor datasets to work as expected.